### PR TITLE
Feature/save cohort and names to cv

### DIFF
--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/domain/CVUserDetails.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/domain/CVUserDetails.java
@@ -1,0 +1,64 @@
+package com.qa.portal.cv.domain;
+
+import com.qa.portal.common.security.QaSecurityContext;
+
+import java.util.Set;
+
+// The identifying details retrieved from the security context
+// saved in Keycloak
+public class CvUserDetails {
+
+    private String firstName;
+    private String lastName;
+    private String userName;
+    private String cohort;
+
+
+
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getCohort() {
+        return cohort;
+    }
+
+    public void setCohort(String cohort) {
+        this.cohort = cohort;
+    }
+
+    public static CvUserDetails retrieveCvUserDetails(QaSecurityContext securityContext){
+
+        CvUserDetails user = new CvUserDetails();
+        user.setFirstName(securityContext.getFirstName());
+        user.setLastName(securityContext.getSurname());
+        user.setUserName(securityContext.getUserName());
+        Set<String> cohorts = securityContext.getCohorts();
+        String cohort = "";
+        if (cohorts.toArray().length > 0) cohort = (String) cohorts.toArray()[0];
+        user.setCohort(cohort);
+        return user;
+
+    }
+}

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/rest/CvManagementController.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/rest/CvManagementController.java
@@ -2,7 +2,6 @@ package com.qa.portal.cv.rest;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import com.qa.portal.cv.domain.CvSearchCriteria;
 import com.qa.portal.cv.domain.CvUserDetails;

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/rest/CvManagementController.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/rest/CvManagementController.java
@@ -2,8 +2,12 @@ package com.qa.portal.cv.rest;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import com.qa.portal.cv.domain.CvSearchCriteria;
+import com.qa.portal.cv.domain.CvUserDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +23,8 @@ public class CvManagementController {
 
     private QaSecurityContext qaSecurityContext;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CvManagementController.class);
+
     public CvManagementController(CvManagementService service, QaSecurityContext qaSecurityContext) {
         super();
         this.service = service;
@@ -28,7 +34,9 @@ public class CvManagementController {
     //	Create
     @PostMapping("/cv")
     public ResponseEntity<CvVersion> createCv(@RequestBody CvVersion newCv) {
-        return ResponseEntity.ok(this.service.createCv(newCv, qaSecurityContext.getUserName()));
+
+        CvUserDetails user = CvUserDetails.retrieveCvUserDetails(this.qaSecurityContext);
+        return ResponseEntity.ok(this.service.createCv(newCv, user));
     }
 
     //  Update

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
@@ -23,8 +23,6 @@ public class CreateCvOperation {
 	// pass in current username, cohort and full name from security context
 	public CvVersion createCv(CvVersion newCv, CvUserDetails user) {
 
-        LOGGER.info("£££"+user.getFirstName());
-
 		newCv.setUserName(user.getUserName());
 		newCv.setFirstName(user.getFirstName());
 		newCv.setSurname(user.getLastName());
@@ -32,11 +30,6 @@ public class CreateCvOperation {
 
 		newCv.setCohort(user.getCohort());
 		newCv.setStatus("In Progress");
-
-		LOGGER.info(newCv.getSurname());
-		LOGGER.info(newCv.getFullName());
-		LOGGER.info(newCv.getFirstName());
-
 
 		repo.save(newCv);
 		

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
@@ -4,7 +4,6 @@ import com.qa.portal.cv.domain.CvUserDetails;
 import com.qa.portal.cv.domain.CvVersion;
 import com.qa.portal.cv.persistence.repository.CvVersionRepository;
 
-import com.qa.portal.cv.rest.CvManagementController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CreateCvOperation.java
@@ -1,26 +1,43 @@
 package com.qa.portal.cv.services;
 
+import com.qa.portal.cv.domain.CvUserDetails;
 import com.qa.portal.cv.domain.CvVersion;
 import com.qa.portal.cv.persistence.repository.CvVersionRepository;
 
+import com.qa.portal.cv.rest.CvManagementController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CreateCvOperation {
 
 	private CvVersionRepository repo;
+	private static final Logger LOGGER = LoggerFactory.getLogger(CreateCvOperation.class);
 	
 	public CreateCvOperation(CvVersionRepository repo) {
 		super();
 		this.repo = repo;
 	}
 
-	// pass in current username from security context
-	public CvVersion createCv(CvVersion newCv, String userName) {
+	// pass in current username, cohort and full name from security context
+	public CvVersion createCv(CvVersion newCv, CvUserDetails user) {
 
-		newCv.setUserName(userName);
-		newCv.setFullName();
-		
+        LOGGER.info("£££"+user.getFirstName());
+
+		newCv.setUserName(user.getUserName());
+		newCv.setFirstName(user.getFirstName());
+		newCv.setSurname(user.getLastName());
+		newCv.setFullName(); // generated from first and last
+
+		newCv.setCohort(user.getCohort());
+		newCv.setStatus("In Progress");
+
+		LOGGER.info(newCv.getSurname());
+		LOGGER.info(newCv.getFullName());
+		LOGGER.info(newCv.getFirstName());
+
+
 		repo.save(newCv);
 		
 		return newCv;

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CvManagementService.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/CvManagementService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.qa.portal.cv.domain.CvSearchCriteria;
+import com.qa.portal.cv.domain.CvUserDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -51,8 +52,8 @@ public class CvManagementService {
     }
     
 //	Create Service
-    public CvVersion createCv(CvVersion newCv, String userName) {
-    	return this.createCvService.createCv(newCv, userName);
+    public CvVersion createCv(CvVersion newCv, CvUserDetails user) {
+    	return this.createCvService.createCv(newCv, user);
     }
     
 //	Update Service

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
@@ -1,5 +1,6 @@
 package com.qa.portal.cv.services;
 
+import com.qa.portal.common.security.QaSecurityContext;
 import org.springframework.stereotype.Component;
 
 import com.qa.portal.cv.domain.CvVersion;
@@ -9,13 +10,17 @@ import com.qa.portal.cv.persistence.repository.CvVersionRepository;
 public class UpdateCvVersionOperation {
 	
 	private CvVersionRepository repo;
-	
-	public UpdateCvVersionOperation(CvVersionRepository repo) {
-		super();
+	private QaSecurityContext securityContext;
+
+	public UpdateCvVersionOperation(CvVersionRepository repo, QaSecurityContext securityContext) {
 		this.repo = repo;
+		this.securityContext = securityContext;
 	}
 
 	public CvVersion updateCv(CvVersion updatedCv) {
+        updatedCv.setFirstName(securityContext.getFirstName());
+        updatedCv.setSurname(securityContext.getSurname());
+        updatedCv.setFullName();
 
 		updatedCv.setStatus("In Progress");
 		repo.save(updatedCv);
@@ -38,7 +43,7 @@ public class UpdateCvVersionOperation {
 	}
 	
 	public CvVersion failCv(CvVersion submittedCv) {
-	
+
 		submittedCv.setStatus("Failed Review");
 		repo.save(submittedCv);
 		return submittedCv;

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
@@ -16,14 +16,14 @@ public class UpdateCvVersionOperation {
 	}
 
 	public CvVersion updateCv(CvVersion updatedCv) {
-		//updatedCv.setFullName(user.getFullName());
+
 		updatedCv.setStatus("In Progress");
 		repo.save(updatedCv);
 		return updatedCv;
 	}
 	
 	public CvVersion submitCv(CvVersion submittedCv) {
-		//submittedCv.setFullName(user.getFullName());
+
 		submittedCv.setStatus("For Review");
 		repo.save(submittedCv);
 		return submittedCv;
@@ -31,14 +31,14 @@ public class UpdateCvVersionOperation {
 	
 	public CvVersion approveCv(CvVersion submittedCv) {
 		//ID should be set to null so a new entry is created and version number should be incremented.
-		//submittedCv.setFullName(user.getFullName());
+
 		submittedCv.setStatus("Approved");
 		repo.save(submittedCv);
 		return submittedCv;
 	}
 	
 	public CvVersion failCv(CvVersion submittedCv) {
-		//submittedCv.setFullName(user.getFullName());
+	
 		submittedCv.setStatus("Failed Review");
 		repo.save(submittedCv);
 		return submittedCv;

--- a/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
+++ b/qa-portal-services/cv-api/src/main/java/com/qa/portal/cv/services/UpdateCvVersionOperation.java
@@ -16,14 +16,14 @@ public class UpdateCvVersionOperation {
 	}
 
 	public CvVersion updateCv(CvVersion updatedCv) {
-		updatedCv.setFullName();
+		//updatedCv.setFullName(user.getFullName());
 		updatedCv.setStatus("In Progress");
 		repo.save(updatedCv);
 		return updatedCv;
 	}
 	
 	public CvVersion submitCv(CvVersion submittedCv) {
-		submittedCv.setFullName();
+		//submittedCv.setFullName(user.getFullName());
 		submittedCv.setStatus("For Review");
 		repo.save(submittedCv);
 		return submittedCv;
@@ -31,14 +31,14 @@ public class UpdateCvVersionOperation {
 	
 	public CvVersion approveCv(CvVersion submittedCv) {
 		//ID should be set to null so a new entry is created and version number should be incremented.
-		submittedCv.setFullName();
+		//submittedCv.setFullName(user.getFullName());
 		submittedCv.setStatus("Approved");
 		repo.save(submittedCv);
 		return submittedCv;
 	}
 	
 	public CvVersion failCv(CvVersion submittedCv) {
-		submittedCv.setFullName();
+		//submittedCv.setFullName(user.getFullName());
 		submittedCv.setStatus("Failed Review");
 		repo.save(submittedCv);
 		return submittedCv;


### PR DESCRIPTION
Sets name and cohort in saved CV from security context when CV is created. Also updates them on save, if the KeyCloak values have changed.

Only roughly tested ... seems to work OK